### PR TITLE
fix: Remove file markers and correct dark mode dropdown CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,3 @@ This is a straightforward and easy-to-use To-Do List application created using b
 * Add visual cues for tasks with upcoming or past due dates.
 * Implement task reminders or notifications.
 * User accounts and cloud synchronization.
-
-[end of README.md]

--- a/index.html
+++ b/index.html
@@ -125,6 +125,14 @@
              color: var(--text-primary);
              border-color: var(--border-secondary);
         }
+        html.dark .recurrence-options-panel select, /* For main add form's recurrence */
+        html.dark .edit-recurrence-panel select {  /* For edit mode's recurrence */
+            background-color: var(--bg-input);
+            color: var(--text-primary);
+            border: 1px solid var(--border-secondary); /* Ensure consistent border */
+            /* Add some padding if needed, though Tailwind classes usually handle this */
+            padding: 0.5rem; /* Tailwind 'p-2' equivalent, adjust as needed */
+        }
         #todoDueDateInput:focus-visible, #todoPriorityInput:focus-visible, #searchInput:focus-visible, #sortSelect:focus-visible {
             border-color: var(--border-focus);
             box-shadow: 0 0 0 1px var(--border-focus);
@@ -1525,5 +1533,3 @@
 
 </body>
 </html>
-
-[end of index.html]


### PR DESCRIPTION
This commit addresses two issues:

1.  Removes extraneous `[end of README.md]` and `[end of index.html]` markers that were mistakenly included in the respective files.
2.  Fixes a CSS bug where the recurrence option dropdown menus (for selecting daily, weekly, etc.) were not visible in dark mode. Specific dark mode styles have been applied to these select elements to ensure proper text and background contrast.